### PR TITLE
Will/babel eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react": "^6.7.1"
   },
   "peerDependencies": {
-    "eslint": ">=3",
+    "eslint": ">=3"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   "homepage": "https://github.com/button/eslint-config-button#readme",
   "dependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint-config-airbnb": "^13.0.0"
-  },
-  "peerDependencies": {
-    "eslint": ">=3",
+    "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.7.1"
+  },
+  "peerDependencies": {
+    "eslint": ">=3",
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/button/eslint-config-button#readme",
   "dependencies": {
+    "babel-eslint": "^7.1.1",
     "eslint-config-airbnb": "^13.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
1. Added `babel-eslint` as a dependency of this plugin.  I flat-out missed this on the first pass.
2. Moved `eslint-plugin-*` to `dependencies` from `peerDependencies`.  They are required to run this extension.  `eslint` makes sense to keep as a peer, as it is the "host" for which this is a plugin ([ref](https://nodejs.org/en/blog/npm/peer-dependencies/)).  I see no advantage deferring the requirement to the "calling" package.