### PR TITLE
Move dependencies to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ npm install --save-dev eslint-config-button
 yarn add eslint-config-button --dev
 ```
 
+Additionally, you'll need to install all dependencies enumerated by:
+
+```bash
+npm info eslint-config-button peerDependencies
+```
+
 ## Usage
 
 In your `.eslintrc` or equivalent:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-button",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Button's eslint config",
   "main": "index.js",
   "scripts": {
@@ -25,15 +25,14 @@
     "url": "https://github.com/button/eslint-config-button/issues"
   },
   "homepage": "https://github.com/button/eslint-config-button#readme",
-  "dependencies": {
+  "dependencies": {},
+  "peerDependencies": {
+    "eslint": ">=3",
     "babel-eslint": "^7.1.1",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.7.1"
-  },
-  "peerDependencies": {
-    "eslint": ">=3"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Unfortunately, `eslint` won't resolve modules not at the top-level of `node_modules/`.  I don't know why I expected it to be otherwise.  Naively optimistic.  So anyways, the `dependencies` here will be installed at `node_modules/eslint-config-button/node_modules/`.  Things work okay with `yarn`, which defaults to installing all modules at the top level, but fails with `npm`.

This change moves `dependencies` to `peerDependencies` and adds instructions to `README.md` for installing,